### PR TITLE
Change error handler for specific game code

### DIFF
--- a/screens/StartScreen.js
+++ b/screens/StartScreen.js
@@ -58,12 +58,12 @@ export default function StartScreen({ navigation, route }) {
   const { loginStatus, setLoginStatus } = useContext(AuthenticationContext);
 
   const handleError = () => {
-    Alert.alert('Please enter 6 numerical digits for the game code.');
+    Alert.alert('Please enter 123456 as the gamecode');
   };
 
   // ensure given code is valid
   const handleJoinPress = () => {
-    code.length === 6
+    code.valueOf() === '123456'
       ? navigation.navigate('SeekerStack', {
         screen: 'SeekerWaitingScreen',
         params: { code },


### PR DESCRIPTION
This gives a warning to the player if they don't use the required game code of **123456**. This code needs to be used because of the way we have things setup on the backend. It's not ideal but it was what we implemented in order for Socket.io to work.