### PR TITLE
fix socket.io only working some times

### DIFF
--- a/routes/drawer/home/seeker/seekerStack.js
+++ b/routes/drawer/home/seeker/seekerStack.js
@@ -81,8 +81,6 @@ export default function SeekerStack({ navigation }) {
     });    
 
     return function cleanup() {
-      ioClient.removeAllListeners('update');
-      ioClient.removeAllListeners('new-player');
     }
 
   };


### PR DESCRIPTION
We removed code that would remove listeners for events "update" and "new-player" that were supposed to be called on the cleanup routine for React's useEffect function, but these caused weird errors where players would get updated on both events for a while until a little while later and no one would receive any updates.